### PR TITLE
人物のratingが0.0の人を排除する処理

### DIFF
--- a/app/controllers/api_features_controller.rb
+++ b/app/controllers/api_features_controller.rb
@@ -137,7 +137,9 @@ class ApiFeaturesController < ApplicationController
       people = Array.new()
       articles.each do |article|
         article.people.each do |person|
-          people.push(person)
+          if person[:rating] != 0.0
+            people.push(person)
+          end
         end
       end
       return people

--- a/app/controllers/api_posts_controller.rb
+++ b/app/controllers/api_posts_controller.rb
@@ -62,11 +62,13 @@ class ApiPostsController < ApplicationController
       # people情報整形
       people = Array.new()
       @post.people.each do |person|
-        obj = {
-          "id" => person.id,
-          "name" => person.name,
-          "furigana" => person.furigana}
-        people.push(obj);
+        if person[:rating] != 0.0
+          obj = {
+            "id" => person.id,
+            "name" => person.name,
+            "furigana" => person.furigana}
+          people.push(obj);
+        end
       end
 
       # アイキャッチ画像設定

--- a/app/controllers/api_shops_controller.rb
+++ b/app/controllers/api_shops_controller.rb
@@ -44,28 +44,7 @@ class ApiShopsController < ApplicationController
     if params[:page] && params[:per]
       newShops = Array.new()
       @shops.page(params[:page]).per(params[:per]).each do |shop|
-        # 人に紐付く時代を全て抽出する
-        periods = Array.new()
-        shop.people.each do |person|
-          person.periods.each do |period|
-            periods.push(period);
-          end
-        end
-
-        # 歴食度の設定
-        rating = cal_rating(shop)
-        # 価格帯の取得
-        price = get_price(shop)
-
-        # 返却用のオブジェクトを作成する
-        obj = { "shop" => shop,
-                "categories" => shop.categories,
-                "people" => shop.people,
-                "periods" => periods.uniq,
-                "rating" => rating,
-                "price" => price
-              }
-        newShops.push(obj);
+        newShops.push(get_shop_json(shop))
       end
       shops = newShops
     else
@@ -80,13 +59,10 @@ class ApiShopsController < ApplicationController
   def show
     @shop = Shop.find(params[:id])
 
-    # 人に紐付く時代を全て抽出する
-    periods = Array.new()
-    @shop.people.each do |person|
-      person.periods.each do |period|
-        periods.push(period);
-      end
-    end
+    # shopに紐付いてる人物を取得する
+    people = get_people(@shop)
+    # shopに紐付けしている時代を取得をする
+    periods = get_periods(@shop.people)
 
     # 歴食度の設定
     rating = cal_rating(@shop)
@@ -98,26 +74,14 @@ class ApiShopsController < ApplicationController
     newPosts = Array.new()
 
     posts.each do |post|
-      # アイキャッチ画像の設定
-      postObj = get_post(post)
-
-      # 人に紐付く時代を全て抽出する
-      periods = get_periods(post.people)
-
-      # 返却用のオブジェクトを作成する
-      obj = { "post" => postObj,
-              "people" => post.people,
-              "periods" => periods.uniq
-            }
-
-      newPosts.push(obj);
+      newPosts.push(get_post_json(post));
     end
 
     # 返却用のオブジェクトを作成する
     rtnObj = { "shop" => @shop,
              "categories" => @shop.categories,
              "posts" => newPosts,
-             "people" => @shop.people.uniq,
+             "people" =>  people.uniq,
              "periods" => periods.uniq,
              "rating" => rating,
              "price" => price

--- a/app/controllers/concerns/related_info.rb
+++ b/app/controllers/concerns/related_info.rb
@@ -33,17 +33,15 @@ module RelatedInfo
     # shopsに紐付いてる人物を取得する
     people = get_people(shop)
     # shopsに紐付けしている時代を取得をする
-    periods = get_periods(people)
+    periods = get_periods(shop.people)
     # 歴食度の設定
     rating = cal_rating(shop)
     # 価格帯の取得
     price = get_price(shop)
-
-    people = people.where("rating != ?", 0.000000000)
     # 返却用のオブジェクトを作成する
     obj = { "shop" => shop,
             "categories" => shop.categories,
-            "people" => people,
+            "people" => shop.people,
             "periods" => periods,
             "rating" => rating,
             "price" => price
@@ -68,11 +66,15 @@ module RelatedInfo
   end
 
   private
-    # 対象の記事/店舗/外部リンクから紐づく人物を取得する
-    def get_people(report)
+    # 対象の情報から紐づく人物を取得する
+    def get_people(article)
       people = Array.new()
-        report.people.each do |person|
-          people.push(person)
+      logger.debug("Hello, world!")
+        article.people.each do |person|
+           logger.debug(person[:rating] )
+           if person[:rating] != 0
+             people.push(person)
+           end
         end
       return people
     end

--- a/app/controllers/concerns/related_info.rb
+++ b/app/controllers/concerns/related_info.rb
@@ -29,6 +29,17 @@ module RelatedInfo
     return periods
   end
 
+  # 対象の情報から紐づく人物を取得する
+  def get_people(article)
+    people = Array.new()
+    article.people.each do |person|
+      if person[:rating] != 0.0
+         people.push(person)
+      end
+    end
+    return people
+  end
+
   def get_shop_json(shop)
     # shopsに紐付いてる人物を取得する
     people = get_people(shop)
@@ -41,7 +52,7 @@ module RelatedInfo
     # 返却用のオブジェクトを作成する
     obj = { "shop" => shop,
             "categories" => shop.categories,
-            "people" => shop.people.uniq,
+            "people" => people.uniq,
             "periods" => periods.uniq,
             "rating" => rating,
             "price" => price
@@ -55,28 +66,14 @@ module RelatedInfo
     # postsに紐付いてる人物を取得する
     people = get_people(post)
     # postsに紐付けしている時代を取得をする
-    periods = get_periods(people)
+    periods = get_periods(post.people)
 
     # 返却用のオブジェクトを作成する
     obj = { "post" => postObj,
-            "people" => post.people,
+            "people" => people.uniq,
             "periods" => periods.uniq
           }
     return obj
   end
-
-  private
-    # 対象の情報から紐づく人物を取得する
-    def get_people(article)
-      people = Array.new()
-      logger.debug("Hello, world!")
-        article.people.each do |person|
-           logger.debug(person[:rating] )
-           if person[:rating] != 0
-             people.push(person)
-           end
-        end
-      return people
-    end
 
 end

--- a/app/controllers/concerns/related_info.rb
+++ b/app/controllers/concerns/related_info.rb
@@ -38,10 +38,12 @@ module RelatedInfo
     rating = cal_rating(shop)
     # 価格帯の取得
     price = get_price(shop)
+
+    people = people.where("rating != ?", 0.000000000)
     # 返却用のオブジェクトを作成する
     obj = { "shop" => shop,
             "categories" => shop.categories,
-            "people" => shop.people,
+            "people" => people,
             "periods" => periods,
             "rating" => rating,
             "price" => price
@@ -66,7 +68,7 @@ module RelatedInfo
   end
 
   private
-    # 対象のお店から紐づく人物を取得する
+    # 対象の記事/店舗/外部リンクから紐づく人物を取得する
     def get_people(report)
       people = Array.new()
         report.people.each do |person|

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -217,12 +217,8 @@ RailsAdmin.config do |config|
          help "必須"
          required true
        end
-       field :rating, :enum do
-       enum do
-         Hash[ ['1: 学者レベル', '2: 趣味レベル','3: 教科書レベル'].zip(['1', '2','3']) ]
-       end
+       field :rating do
          label "ランク"
-         help "1-3段階　有名だと3"
          required true
        end
        field :periods do

--- a/db/migrate/20160620054851_change_rating_to_people.rb
+++ b/db/migrate/20160620054851_change_rating_to_people.rb
@@ -1,0 +1,11 @@
+class ChangeRatingToPeople < ActiveRecord::Migration
+  #変更後の型
+  def up
+    change_column :people, :rating, :float, null: false
+  end
+
+  #変更前の型
+  def down
+    change_column :people, :rating, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160602084342) do
+ActiveRecord::Schema.define(version: 20160620054851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,7 +60,8 @@ ActiveRecord::Schema.define(version: 20160602084342) do
 
   create_table "feature_details", force: :cascade do |t|
     t.integer  "feature_id"
-    t.string   "title",                    null: false
+    t.string   "title"
+    t.text     "content"
     t.string   "related_type"
     t.integer  "related_id",   default: 0
     t.integer  "order",        default: 0, null: false
@@ -69,27 +70,26 @@ ActiveRecord::Schema.define(version: 20160602084342) do
   end
 
   create_table "features", force: :cascade do |t|
-    t.string   "title",                                null: false
+    t.string   "title",                          null: false
     t.text     "content"
-    t.string   "image",                                null: false
+    t.string   "image",                          null: false
     t.string   "quotation_url"
     t.string   "quotation_name"
-    t.integer  "feature_details_type", default: 0,     null: false
-    t.boolean  "is_map",               default: false
-    t.integer  "category_id",          default: 0,     null: false
-    t.boolean  "status",               default: false
-    t.integer  "user_id",                              null: false
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
+    t.boolean  "is_map",         default: false
+    t.integer  "category_id",    default: 0,     null: false
+    t.integer  "status",         default: 0,     null: false
+    t.integer  "user_id",                        null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
     t.datetime "published_at"
   end
 
   create_table "people", force: :cascade do |t|
-    t.string   "name",                   null: false
+    t.string   "name",                     null: false
     t.string   "furigana"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.integer  "rating",     default: 0, null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.float    "rating",     default: 0.0, null: false
   end
 
   create_table "people_periods", id: false, force: :cascade do |t|


### PR DESCRIPTION
## 概要
昭和人や江戸人などの、お店に年代を紐付けするために作成されることになった。
その人を表示させないように、対応する必要があった。

## 対応画面
post周りとshop周りの人物検索部分

## 対応内容
* if文でperson[:rating] != 0.0
* get_peopleをprivate→public
* ratingをint →floatに
* 人物登録の管理画面の修正