### PR TITLE
共有化漏れ対応

### DIFF
--- a/app/controllers/api_posts_controller.rb
+++ b/app/controllers/api_posts_controller.rb
@@ -143,18 +143,7 @@ class ApiPostsController < ApplicationController
     # 返却用オブジェクト作成
     newPosts = Array.new()
     posts.each do |post|
-      # アイキャッチ画像の設定
-      postObj = get_post(post)
-
-      # 人に紐付く時代を全て抽出する
-      periods = get_periods(post.people)
-
-      obj = { "post" => postObj,
-              "people" => post.people,
-              "periods" => periods.uniq
-            }
-
-      newPosts.push(obj)
+      newPosts.push(get_post_json(post))
     end
 
     render json: newPosts

--- a/app/controllers/api_users_controller.rb
+++ b/app/controllers/api_users_controller.rb
@@ -18,19 +18,7 @@ class ApiUsersController < ApplicationController
     newPosts = Array.new()
 
     posts.each do |post|
-      # アイキャッチ画像の設定
-      postObj = get_post(post)
-
-      # 人に紐付く時代を全て抽出する
-      periods = get_periods(post.people)
-
-      # 返却用のオブジェクトを作成する
-      obj = { "post" => postObj,
-              "people" => post.people,
-              "periods" => periods.uniq
-            }
-
-      newPosts.push(obj);
+      newPosts.push(get_post_json(post));
     end
 
     user = {


### PR DESCRIPTION
## 概要
ライター画面と関連エピソードで、rating=0.0の人物も表示されてしまっていた問題がありました

## 対応内容
共有メソッド利用しました。これで、rating=0.0の人物を表示しないように修正しました

## 対応画面
ライター画面
エピソード画面での関連エピソード

## issue番号
#24 