### PR TITLE
外部リンクの住所入力対応

### DIFF
--- a/app/controllers/concerns/api_geocoder.rb
+++ b/app/controllers/concerns/api_geocoder.rb
@@ -1,0 +1,7 @@
+module ApiGeocoder
+  # 緯度経度の計算
+  def get_geocoder(address)
+    Geocoder.configure(:language  => :ja,  :units => :km )
+    return Geocoder.coordinates(address);
+  end
+end

--- a/app/controllers/external_links_controller.rb
+++ b/app/controllers/external_links_controller.rb
@@ -1,0 +1,38 @@
+class ExternalLinksController < ApplicationController
+  load_and_authorize_resource
+  before_action :set_external_link, only: [:update]
+  include ApiGeocoder
+
+  # POST /external_links
+  # POST /external_links.json
+  def create
+    # 住所から緯度経度を求める
+    addressPlace = get_geocoder(external_link_params[:province]+external_link_params[:city]+external_link_params[:address1]);
+    # 緯度経度を代入する
+    @external_link = ExternalLink.new(external_link_params.merge(latitude: addressPlace[0], longitude: addressPlace[1]))
+    @external_link.save
+    redirect_to "/admin/external_link"
+  end
+
+  # PATCH/PUT /external_links/1
+  # PATCH/PUT /external_links/1.json
+  def update
+    # 住所から緯度経度を求める
+    addressPlace = get_geocoder(external_link_params[:province]+external_link_params[:city]+external_link_params[:address1]);
+    # 緯度経度を代入する
+    @external_link.update(external_link_params.merge(latitude: addressPlace[0], longitude: addressPlace[1]))
+    redirect_to "/admin/external_link"
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_external_link
+      @external_link = ExternalLink.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def external_link_params
+      params.require(:external_link).permit(:name, :content, :url, :image, :quotation_url, :quotation_name, :post_quotation_url, :post_quotation_name, :province, :city, :address1, :address2, :latitude, :longitude, :person_ids => [])
+    end
+
+end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -6,6 +6,7 @@ class ShopsController < ApplicationController
 
   require 'net/http'
   include Prerender
+  include ApiGeocoder
 
   # GET /shops
   # GET /shops.json
@@ -31,8 +32,7 @@ class ShopsController < ApplicationController
   # POST /shops.json
   def create
     # 住所から緯度経度を求める
-    Geocoder.configure(:language  => :ja,  :units => :km )
-    addressPlace = Geocoder.coordinates(shop_params[:province]+shop_params[:city]+shop_params[:address1]);
+    addressPlace = get_geocoder(shop_params[:province]+shop_params[:city]+shop_params[:address1]);
     #歴食度_合計
     levelArray  = ["history_level", "building_level", "menu_level", "person_level", "episode_level"]
     setShopLevel = [nil, nil, nil, nil, nil]
@@ -56,8 +56,7 @@ class ShopsController < ApplicationController
   # PATCH/PUT /shops/1.json
   def update
     # 住所から緯度経度を求める
-    Geocoder.configure(:language  => :ja,  :units => :km )
-    addressPlace = Geocoder.coordinates(shop_params[:province]+shop_params[:city]+shop_params[:address1]);
+    addressPlace = get_geocoder(shop_params[:province]+shop_params[:city]+shop_params[:address1]);
     #歴食度_合計
     levelArray  = ["history_level", "building_level", "menu_level", "person_level", "episode_level"]
     setShopLevel = [nil, nil, nil, nil, nil]

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -709,6 +709,8 @@ RailsAdmin.config do |config|
             end
             field :image  do
               label "画像"
+              help "必須"
+              required true
             end
             field :quotation_url do
               label "引用したURL"

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -706,19 +706,33 @@ RailsAdmin.config do |config|
             end
             field :content do
               label "内容"
-              help "必須"
-              required true
             end
             field :image  do
               label "画像"
-              help "必須"
-              required true
             end
             field :quotation_url do
               label "引用したURL"
             end
             field :quotation_name do
               label "引用したサイト名"
+            end
+            field :province do
+              label "都道府県"
+              help "必須"
+              required true
+            end
+            field :city do
+              label "市町村"
+              help "必須"
+              required true
+            end
+            field :address1 do
+              label "その他住所"
+              help "必須 例) 銀座8-14-7"
+              required true
+            end
+            field :address2 do
+              label "建物名"
             end
             field :people do
               label "関係のある人物"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,10 @@ Rails.application.routes.draw do
   post 'admin/feature/new', to: 'features#create'
   put 'admin/feature/:id/edit', to: 'features#update'
 
+  # ADMIN_ ExternalLink
+  post 'admin/external_link/new', to: 'external_links#create'
+  put 'admin/external_link/:id/edit', to: 'external_links#update'
+
 # site map
   case Rails.env
     when 'production'

--- a/db/migrate/20160803001712_add_column_to_external_links.rb
+++ b/db/migrate/20160803001712_add_column_to_external_links.rb
@@ -1,0 +1,10 @@
+class AddColumnToExternalLinks < ActiveRecord::Migration
+  def change
+    add_column :external_links, :province,  :string
+    add_column :external_links, :city,  :string
+    add_column :external_links, :address1,  :string
+    add_column :external_links, :address2,  :string
+    add_column :external_links, :latitude,  :float
+    add_column :external_links, :longitude,  :float
+  end
+end

--- a/db/migrate/20160803011601_change_image_to_external_links.rb
+++ b/db/migrate/20160803011601_change_image_to_external_links.rb
@@ -1,0 +1,13 @@
+class ChangeImageToExternalLinks < ActiveRecord::Migration
+  #変更後の型
+  def up
+    change_column :external_links, :image, :string, null: true
+    change_column :external_links, :name, :string, null: false
+  end
+
+  #変更前の型
+  def down
+    change_column :external_links, :image, :string, null: false
+    change_column :external_links, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160625154206) do
+ActiveRecord::Schema.define(version: 20160803011601) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,13 +41,19 @@ ActiveRecord::Schema.define(version: 20160625154206) do
   add_index "categories_shops", ["shop_id"], name: "index_categories_shops_on_shop_id", using: :btree
 
   create_table "external_links", force: :cascade do |t|
-    t.string   "name"
+    t.string   "name",           null: false
     t.text     "content"
-    t.string   "image",          null: false
+    t.string   "image"
     t.string   "quotation_url"
     t.string   "quotation_name"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "province"
+    t.string   "city"
+    t.string   "address1"
+    t.string   "address2"
+    t.float    "latitude"
+    t.float    "longitude"
   end
 
   create_table "feature_details", force: :cascade do |t|


### PR DESCRIPTION
### 目的
外部リンクで住所を入力してもらい、緯度経度をDBで保持すること

### 開発対応
外部リンク
* 緯度経度計算処理を追加
* 住所を入力できるようにした 
* nameをDB必須項目に、imageをDB必須項目から解除

緯度経度計算を共通化処理に変更

## チケット番号
close #36 