### PR TITLE
時代を古い順に表示するように修正

### DIFF
--- a/app/controllers/concerns/related_info.rb
+++ b/app/controllers/concerns/related_info.rb
@@ -26,7 +26,7 @@ module RelatedInfo
         periods.push(period);
       end
     end
-    return periods
+    return periods.sort{ |a, b| a[:id] <=> b[:id] }
   end
 
   # 対象の情報から紐づく人物を取得する


### PR DESCRIPTION
close #35
 
### 問題
時代タグの並び順が時代も古い順になっていない。
「江戸」「昭和」「大正」という順になっていたりする。

### 対応内容
時代順に並ぶように、sortをかけるように修正しました。
 