### PR TITLE
trello名: 管理画面の記事編集画面で、「公開時間」が必須入力になってしまっている。

### DIFF
--- a/app/controllers/features_controller.rb
+++ b/app/controllers/features_controller.rb
@@ -10,7 +10,11 @@ class FeaturesController < ApplicationController
   def create
     setPublishedAt = feature_time_params[:published_at].split(/\D+/)
 
-    @feature = Feature.new(feature_params.merge(published_at: Time.zone.local(setPublishedAt[0],setPublishedAt[1],setPublishedAt[2],setPublishedAt[3],setPublishedAt[4])))
+    if feature_time_params:[published_at] == nil
+      @feature = Feature.new(feature_params.merge(published_at: Time.zone.local(setPublishedAt[0],setPublishedAt[1],setPublishedAt[2],setPublishedAt[3],setPublishedAt[4])))
+    else
+      @feature = Feature.new(feature_params)
+    end
     @feature.save
     Net::HTTP.get_response(URI.parse(api_url("feature",@feature[:id])))
     redirect_to "/admin/feature"
@@ -21,7 +25,11 @@ class FeaturesController < ApplicationController
   def update
     ## 公開日の設定
     setPublishedAt = feature_time_params[:published_at].split(/\D+/)
-    @feature.update(feature_params.merge(published_at: Time.zone.local(setPublishedAt[0],setPublishedAt[1],setPublishedAt[2],setPublishedAt[3],setPublishedAt[4])))
+    if feature_time_params:[published_at] == nil
+      @feature.update(feature_params.merge(published_at: Time.zone.local(setPublishedAt[0],setPublishedAt[1],setPublishedAt[2],setPublishedAt[3],setPublishedAt[4])))
+    else
+      @feature.update(feature_params)
+    end
     Net::HTTP.get_response(URI.parse(api_url("feature",@feature[:id])))
     redirect_to "/admin/feature"
   end

--- a/app/controllers/features_controller.rb
+++ b/app/controllers/features_controller.rb
@@ -8,9 +8,8 @@ class FeaturesController < ApplicationController
   # POST /feature
   # POST /feature.json
   def create
-    setPublishedAt = feature_time_params[:published_at].split(/\D+/)
-
-    if feature_time_params:[published_at] == nil
+    if feature_time_params:[published_at] != ""
+      setPublishedAt = feature_time_params[:published_at].split(/\D+/)
       @feature = Feature.new(feature_params.merge(published_at: Time.zone.local(setPublishedAt[0],setPublishedAt[1],setPublishedAt[2],setPublishedAt[3],setPublishedAt[4])))
     else
       @feature = Feature.new(feature_params)
@@ -24,8 +23,8 @@ class FeaturesController < ApplicationController
   # PATCH/PUT /feature/1.json
   def update
     ## 公開日の設定
-    setPublishedAt = feature_time_params[:published_at].split(/\D+/)
-    if feature_time_params:[published_at] == nil
+    if feature_time_params:[published_at] != ""
+      setPublishedAt = feature_time_params[:published_at].split(/\D+/)
       @feature.update(feature_params.merge(published_at: Time.zone.local(setPublishedAt[0],setPublishedAt[1],setPublishedAt[2],setPublishedAt[3],setPublishedAt[4])))
     else
       @feature.update(feature_params)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -30,7 +30,12 @@ class PostsController < ApplicationController
   # POST /posts.json
   def create
     setPublishedAt = post_time_params[:published_at].split(/\D+/)
-    @post = Post.new(post_params.merge(published_at: Time.zone.local(setPublishedAt[0],setPublishedAt[1],setPublishedAt[2],setPublishedAt[3],setPublishedAt[4])))
+    if post_time_params[:published_at] == nil
+      @post = Post.new(post_params.merge(published_at: Time.zone.local(setPublishedAt[0],setPublishedAt[1],setPublishedAt[2],setPublishedAt[3],setPublishedAt[4])))
+    else
+      @post = Post.new(post_params)
+    end
+
     @post.save
     Net::HTTP.get_response(URI.parse(api_url("post",@post[:id])))
     redirect_to "/admin/post"
@@ -40,7 +45,11 @@ class PostsController < ApplicationController
   # PATCH/PUT /posts/1.json
   def update
     setPublishedAt = post_time_params[:published_at].split(/\D+/)
-    @post.update(post_params.merge(published_at: Time.zone.local(setPublishedAt[0],setPublishedAt[1],setPublishedAt[2],setPublishedAt[3],setPublishedAt[4])))
+    if post_time_params[:published_at]  == nil
+      @post.update(post_params.merge(published_at: Time.zone.local(setPublishedAt[0],setPublishedAt[1],setPublishedAt[2],setPublishedAt[3],setPublishedAt[4])))
+    else
+      @post.update(post_params)
+    end
     Net::HTTP.get_response(URI.parse(api_url("post",@post[:id])))
     redirect_to "/admin/post"
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -29,8 +29,8 @@ class PostsController < ApplicationController
   # POST /posts
   # POST /posts.json
   def create
-    setPublishedAt = post_time_params[:published_at].split(/\D+/)
-    if post_time_params[:published_at] == nil
+    if post_time_params[:published_at] != ""
+      setPublishedAt = post_time_params[:published_at].split(/\D+/)
       @post = Post.new(post_params.merge(published_at: Time.zone.local(setPublishedAt[0],setPublishedAt[1],setPublishedAt[2],setPublishedAt[3],setPublishedAt[4])))
     else
       @post = Post.new(post_params)
@@ -44,8 +44,8 @@ class PostsController < ApplicationController
   # PATCH/PUT /posts/1
   # PATCH/PUT /posts/1.json
   def update
-    setPublishedAt = post_time_params[:published_at].split(/\D+/)
-    if post_time_params[:published_at]  == nil
+    if post_time_params[:published_at] != ""
+      setPublishedAt = post_time_params[:published_at].split(/\D+/)
       @post.update(post_params.merge(published_at: Time.zone.local(setPublishedAt[0],setPublishedAt[1],setPublishedAt[2],setPublishedAt[3],setPublishedAt[4])))
     else
       @post.update(post_params)

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -486,6 +486,7 @@ RailsAdmin.config do |config|
       end
       field :category  do
         label "対応するカテゴリを選択してください"
+        required true
       end
       field :post_details do
         label "記事セクション"
@@ -500,7 +501,6 @@ RailsAdmin.config do |config|
       end
       field :published_at do
         label "公開時間"
-        required true
       end
       field :shops  do
         label "関連店舗"
@@ -629,7 +629,6 @@ RailsAdmin.config do |config|
           end
           field :published_at do
             label "公開時間"
-            required true
           end
           field :user do
             label "ライター"


### PR DESCRIPTION
close #44 

### 問題
postと特集記事の公開時間を必須から解除

### バグ対応
* 管理画面から必須を制御を削除
* features_controllerとposts_controllerの公開時間未設定の時の対応