### PR TITLE
管理画面でキャッシュAPIボタンを作成 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,9 @@ gem 'google-analytics-rails'
 # url redirect
 gem 'rack-rewrite'
 
+# post
+gem 'httpclient', '~> 2.7', '>= 2.7.1'
+
 # prerender.io(SEO for SPA)
 gem 'prerender_rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,7 @@ GEM
     google-analytics-rails (1.1.0)
     haml (4.0.7)
       tilt
+    httpclient (2.8.1)
     i18n (0.7.0)
     inflecto (0.0.2)
     ipaddress (0.8.0)
@@ -338,6 +339,7 @@ DEPENDENCIES
   font-awesome-rails
   geocoder
   google-analytics-rails
+  httpclient (~> 2.7, >= 2.7.1)
   jbuilder (~> 2.0)
   jquery-rails
   kaminari
@@ -356,3 +358,6 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.11.2

--- a/app/views/rails_admin/main/cache_make.html.erb
+++ b/app/views/rails_admin/main/cache_make.html.erb
@@ -1,0 +1,16 @@
+<%= form_tag("", method: "put") do %>
+    <table class="table table-striped　table-bordered">
+        <tr>
+            <th>Name</th>
+            <th>Order</th>
+        </tr>
+        <% @objects.each do |object| %>
+            <tr>
+                <td><%=object.name%></td>
+                <td><input type="number" value="<%=object.order%>" name="products[][order]"></td>
+                <input type="hidden" value="<%=object.id%>" name="products[][id]"/>
+            </tr>
+        <% end %>
+    </table>
+    <%= submit_tag("更新") %>
+<% end %>

--- a/app/views/rails_admin/main/cache_make.html.erb
+++ b/app/views/rails_admin/main/cache_make.html.erb
@@ -1,13 +1,11 @@
 <%= form_tag("", method: "put") do %>
     <table class="table table-striped　table-bordered">
         <tr>
-            <th>Name</th>
-            <th>Order</th>
+            <th>id</th>
         </tr>
         <% @objects.each do |object| %>
             <tr>
-                <td><%=object.name%></td>
-                <td><input type="number" value="<%=object.order%>" name="products[][order]"></td>
+                <td><%=object.id%></td>
                 <input type="hidden" value="<%=object.id%>" name="products[][id]"/>
             </tr>
         <% end %>

--- a/app/views/rails_admin/main/cache_make.html.erb
+++ b/app/views/rails_admin/main/cache_make.html.erb
@@ -1,14 +1,7 @@
 <%= form_tag("", method: "put") do %>
     <table class="table table-striped　table-bordered">
-        <tr>
-            <th>id</th>
-        </tr>
-        <% @objects.each do |object| %>
-            <tr>
-                <td><%=object.id%></td>
-                <input type="hidden" value="<%=object.id%>" name="products[][id]"/>
-            </tr>
-        <% end %>
+      <%= label :page, :cacheid %>
+      <%= text_field :page, :name %>
     </table>
-    <%= submit_tag("更新") %>
+    <%= submit_tag("キャッシュ作成/更新") %>
 <% end %>

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -32,7 +32,10 @@ RailsAdmin.config do |config|
     show_in_app
 
     # カスタムアクションを宣言
-    cache_make
+    if Rails.env == 'production'
+      cache_make
+    end
+
   end
 
   ## ユーザーの管理レベル調整

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,3 +1,5 @@
+require Rails.root.join('lib', 'cache_make.rb')
+
 RailsAdmin.config do |config|
 
   ### Popular gems integration
@@ -18,7 +20,6 @@ RailsAdmin.config do |config|
   # config.audit_with :paper_trail, 'User', 'PaperTrail::Version' # PaperTrail >= 3.0.0
 
   ### More at https://github.com/sferik/rails_admin/wiki/Base-configuration
-
   config.actions do
     dashboard
     index
@@ -30,9 +31,8 @@ RailsAdmin.config do |config|
     delete
     show_in_app
 
-    ## With an audit adapter, you can add:
-    # history_index
-    # history_show
+    # カスタムアクションを宣言
+    cache_make
   end
 
   ## ユーザーの管理レベル調整

--- a/config/locales/rails_admin.en.yml
+++ b/config/locales/rails_admin.en.yml
@@ -68,6 +68,10 @@ en:
         title: "List of %{model_label_plural}"
         menu: "List"
         breadcrumb: "%{model_label_plural}"
+      cache_make:
+        title: "%{model_label_plural}のキャッシュ作成/更新"
+        menu: "キャッシュ作成/更新"
+        breadcrumb: "%{model_label_plural}"
       show:
         title: "Details for %{model_label} '%{object_label}'"
         menu: "Show"

--- a/config/locales/rails_admin.jp.yml
+++ b/config/locales/rails_admin.jp.yml
@@ -48,6 +48,10 @@ ja:
         title: "%{model_label_plural}の一覧"
         menu: "一覧"
         breadcrumb: "%{model_label_plural}"
+      cache_make:
+        title: "%{model_label_plural}のキャッシュ作成/更新"
+        menu: "キャッシュ作成/更新"
+        breadcrumb: "%{model_label_plural}"
       show:
         title: "%{model_label} '%{object_label}'の詳細"
         menu: "詳細"

--- a/lib/cache_make.rb
+++ b/lib/cache_make.rb
@@ -29,7 +29,7 @@ module RailsAdmin
                             # 一覧表示　（モデル内容を全て取得）
                             @objects = list_entries(@model_config, :destroy, get_association_scope_from_params, false)
                         elsif request.put?
-                            # 表示順の更新
+                            # 通信用
                             http_client = HTTPClient.new
 
                             # prerender.ioの対応

--- a/lib/cache_make.rb
+++ b/lib/cache_make.rb
@@ -4,7 +4,7 @@ require "rails_admin/config/actions/base"
 module RailsAdmin
     module Config
         module Actions
-            class DisplayOrderAction < RailsAdmin::Config::Actions::Base
+            class CacheMake < RailsAdmin::Config::Actions::Base
                 RailsAdmin::Config::Actions.register(self)
 
                 # カスタムコントローラを作成するため、以下を true にする

--- a/lib/cache_make.rb
+++ b/lib/cache_make.rb
@@ -1,0 +1,45 @@
+require "rails_admin/config/actions"
+require "rails_admin/config/actions/base"
+
+module RailsAdmin
+    module Config
+        module Actions
+            class DisplayOrderAction < RailsAdmin::Config::Actions::Base
+                RailsAdmin::Config::Actions.register(self)
+
+                # カスタムコントローラを作成するため、以下を true にする
+                register_instance_option :collection? do
+                    true
+                end
+
+                register_instance_option :bulkable do
+                    true
+                end
+
+                register_instance_option :http_methods do
+                    [:get, :put]
+                end
+
+                # コントローラーアクションの処理
+                register_instance_option :controller do
+                    Proc.new do
+                        if request.get?
+                            # 一覧表示　（モデル内容を全て取得）
+                            @objects = list_entries(@model_config, :destroy, get_association_scope_from_params, false)
+                        elsif request.put?
+                            # 表示順の更新
+                            objects = list_entries(@model_config, :destroy)
+                            params[:products].each do |params_product|
+                                object = objects.find(params_product[:id])
+                                object.update_attributes(order: params_product[:order])
+                            end
+                            redirect_to(:back)
+                        else
+                            raise "エラーメッセージ"
+                        end
+                    end
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
close #42 

## 概要
キャッシュ作成が面倒だったので、管理画面でボタン押下して作成できるようにする

## 対応内容
操作画面をひとつ追加しました。
対象のIDを入力してボタンを押下すると、Prerender.ioとFacebookのキャッシュを同時作成/更新をするようにしました。

## デザイン上の変更箇所
管理画面のタブ表示部分

## 注意事項
* 情報管理上で本番環境のみでしか、動作しないように制御しています
* 記事、店舗、特集とどれも作成できるようになったと思います。

