### PR TITLE
ケアレスミスの修正

### DIFF
--- a/app/controllers/features_controller.rb
+++ b/app/controllers/features_controller.rb
@@ -8,7 +8,7 @@ class FeaturesController < ApplicationController
   # POST /feature
   # POST /feature.json
   def create
-    if feature_time_params:[published_at] != ""
+    if feature_time_params[:published_at] != ""
       setPublishedAt = feature_time_params[:published_at].split(/\D+/)
       @feature = Feature.new(feature_params.merge(published_at: Time.zone.local(setPublishedAt[0],setPublishedAt[1],setPublishedAt[2],setPublishedAt[3],setPublishedAt[4])))
     else
@@ -23,7 +23,7 @@ class FeaturesController < ApplicationController
   # PATCH/PUT /feature/1.json
   def update
     ## 公開日の設定
-    if feature_time_params:[published_at] != ""
+    if feature_time_params[:published_at] != ""
       setPublishedAt = feature_time_params[:published_at].split(/\D+/)
       @feature.update(feature_params.merge(published_at: Time.zone.local(setPublishedAt[0],setPublishedAt[1],setPublishedAt[2],setPublishedAt[3],setPublishedAt[4])))
     else


### PR DESCRIPTION
## 概要
特集ページで公開時間入力をしたい時に Errorが起きる問題

## 修正内容
「:」の位置付けミス