### PR TITLE
FacebookのError対応と記事公開時のキャッシュ作成

### DIFF
--- a/app/controllers/api_posts_controller.rb
+++ b/app/controllers/api_posts_controller.rb
@@ -177,7 +177,7 @@ class ApiPostsController < ApplicationController
       end
     # 公開処理の場合
     else
-      set_cache_url = "http://www.rekishoku.jp/app/shop/150" 
+      set_cache_url = "http://www.rekishoku.jp/app/post/" + @post[:id].to_s
       api_url(set_cache_url)
       result = @post.update(post_params)
     end

--- a/app/controllers/api_posts_controller.rb
+++ b/app/controllers/api_posts_controller.rb
@@ -177,7 +177,8 @@ class ApiPostsController < ApplicationController
       end
     # 公開処理の場合
     else
-      Net::HTTP.get_response(URI.parse(api_url("post",@post[:id])))
+      set_cache_url = "http://www.rekishoku.jp/app/shop/150" 
+      api_url(set_cache_url)
       result = @post.update(post_params)
     end
     if result

--- a/app/controllers/api_posts_controller.rb
+++ b/app/controllers/api_posts_controller.rb
@@ -1,7 +1,6 @@
 class ApiPostsController < ApplicationController
   authorize_resource :class => false
 
-  require 'net/http'
   include Prerender
   include ShopInfo
   include RelatedInfo
@@ -177,8 +176,8 @@ class ApiPostsController < ApplicationController
       end
     # 公開処理の場合
     else
-      set_cache_url = "http://www.rekishoku.jp/app/post/" + @post[:id].to_s
-      api_url(set_cache_url)
+      cache_url = "http://www.rekishoku.jp/app/post/" + @post[:id].to_s
+      create_page_cache(cache_url)
       result = @post.update(post_params)
     end
     if result

--- a/app/controllers/concerns/prerender.rb
+++ b/app/controllers/concerns/prerender.rb
@@ -8,9 +8,9 @@ module Prerender
 
       # prerender.ioの対応
       endpoint_uri = 'http://api.prerender.io/recache'
-      request_content = {:prerenderToken => "zeJzE6OXcjajAT4aENY9", :url => set_url}
+      request_content = {:prerenderToken => ENV["PRERENDER_TOKEN"], :url => set_url}
       content_json = request_content.to_json
-      http_client.set_auth(endpoint_uri, "rekishoku@gmail.com", "@Startup2015")
+      http_client.set_auth(endpoint_uri, ENV["PRERENDER_MEAL"], ENV["PRERENDER_PASSWORD"]))
       http_client.post_content(endpoint_uri, content_json, 'Content-Type' => 'application/json')
 
       # Facebook対応

--- a/app/controllers/concerns/prerender.rb
+++ b/app/controllers/concerns/prerender.rb
@@ -1,18 +1,23 @@
 module Prerender
-  BASE_API_URL = "http://api.prerender.io/recache".freeze
 
   # API実行用のURLを返却
-  def api_url(report_type, report_id)
-    case Rails.env
-    when 'production'
-      set_url = "http://www.rekishoku.jp/app/" + report_type + "/" + report_id.to_s
-    end
+  def api_url(set_url)
+    if Rails.env == 'production'
+      # 通信用
+      http_client = HTTPClient.new
 
-    parameters = {
-      "prerenderToken" => ENV['PRERENDER_TOKEN'],
-      "url" => set_url,
-    }
-    logger.debug(BASE_API_URL + "?" + parameters.map{|key,value| URI.encode(key.to_s) + "=" + URI.encode(value.to_s)}.join("&"))
-    return BASE_API_URL + "?" + parameters.map{|key,value| URI.encode(key.to_s) + "=" + URI.encode(value.to_s)}.join("&")
+      # prerender.ioの対応
+      endpoint_uri = 'http://api.prerender.io/recache'
+      request_content = {:prerenderToken => "zeJzE6OXcjajAT4aENY9", :url => set_url}
+      content_json = request_content.to_json
+      http_client.set_auth(endpoint_uri, "rekishoku@gmail.com", "@Startup2015")
+      http_client.post_content(endpoint_uri, content_json, 'Content-Type' => 'application/json')
+
+      # Facebook対応
+      endpoint_uri = 'https://graph.facebook.com'
+      request_content = {:scrape => "true", :id => set_url}
+      content_json = request_content.to_json
+      http_client.post_content(endpoint_uri, content_json, 'Content-Type' => 'application/json')
+    end
   end
 end

--- a/app/controllers/concerns/prerender.rb
+++ b/app/controllers/concerns/prerender.rb
@@ -1,21 +1,21 @@
 module Prerender
 
   # API実行用のURLを返却
-  def api_url(set_url)
+  def create_page_cache(cache_url)
     if Rails.env == 'production'
       # 通信用
       http_client = HTTPClient.new
 
       # prerender.ioの対応
       endpoint_uri = 'http://api.prerender.io/recache'
-      request_content = {:prerenderToken => ENV["PRERENDER_TOKEN"], :url => set_url}
+      request_content = {:prerenderToken => ENV["PRERENDER_TOKEN"], :url => cache_url}
       content_json = request_content.to_json
-      http_client.set_auth(endpoint_uri, ENV["PRERENDER_MEAL"], ENV["PRERENDER_PASSWORD"]))
+      http_client.set_auth(endpoint_uri, ENV["PRERENDER_MEAL"], ENV["PRERENDER_PASSWORD"])
       http_client.post_content(endpoint_uri, content_json, 'Content-Type' => 'application/json')
 
       # Facebook対応
       endpoint_uri = 'https://graph.facebook.com'
-      request_content = {:scrape => "true", :id => set_url}
+      request_content = {:scrape => "true", :id => cache_url}
       content_json = request_content.to_json
       http_client.post_content(endpoint_uri, content_json, 'Content-Type' => 'application/json')
     end

--- a/app/controllers/features_controller.rb
+++ b/app/controllers/features_controller.rb
@@ -15,7 +15,6 @@ class FeaturesController < ApplicationController
       @feature = Feature.new(feature_params)
     end
     @feature.save
-    Net::HTTP.get_response(URI.parse(api_url("feature",@feature[:id])))
     redirect_to "/admin/feature"
   end
 
@@ -29,7 +28,6 @@ class FeaturesController < ApplicationController
     else
       @feature.update(feature_params)
     end
-    Net::HTTP.get_response(URI.parse(api_url("feature",@feature[:id])))
     redirect_to "/admin/feature"
   end
 

--- a/app/controllers/features_controller.rb
+++ b/app/controllers/features_controller.rb
@@ -2,9 +2,6 @@ class FeaturesController < ApplicationController
   load_and_authorize_resource
   before_action :set_feature, only: [:edit, :update, :destroy]
 
-  require 'net/http'
-  include Prerender
-
   # POST /feature
   # POST /feature.json
   def create

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -37,7 +37,6 @@ class PostsController < ApplicationController
     end
 
     @post.save
-    Net::HTTP.get_response(URI.parse(api_url("post",@post[:id])))
     redirect_to "/admin/post"
   end
 
@@ -50,7 +49,6 @@ class PostsController < ApplicationController
     else
       @post.update(post_params)
     end
-    Net::HTTP.get_response(URI.parse(api_url("post",@post[:id])))
     redirect_to "/admin/post"
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,9 +2,6 @@ class PostsController < ApplicationController
   load_and_authorize_resource
   before_action :set_post, only: [:edit, :update, :destroy]
 
-  require 'net/http'
-  include Prerender
-
   # GET /posts
   # GET /posts.json
   def index

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -48,7 +48,6 @@ class ShopsController < ApplicationController
     # 緯度経度と歴食度を代入する
     @shop = Shop.new(shop_params.merge(latitude: addressPlace[0], longitude: addressPlace[1], total_level: total, history_level: setShopLevel[0], building_level: setShopLevel[1], menu_level: setShopLevel[2], person_level: setShopLevel[3], episode_level: setShopLevel[4]))
     @shop.save
-    Net::HTTP.get_response(URI.parse(api_url("shop",@shop[:id])))
     redirect_to "/admin/shop"
   end
 
@@ -72,7 +71,6 @@ class ShopsController < ApplicationController
 
     # 緯度経度と歴食度を代入する
     @shop.update(shop_params.merge(latitude: addressPlace[0], longitude: addressPlace[1], total_level: total, history_level: setShopLevel[0], building_level: setShopLevel[1], menu_level: setShopLevel[2], person_level: setShopLevel[3], episode_level: setShopLevel[4]))
-    Net::HTTP.get_response(URI.parse(api_url("shop",@shop[:id])))
     redirect_to "/admin/shop"
   end
 

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -4,8 +4,6 @@ class ShopsController < ApplicationController
   before_action :set_shopscategories, only: [:new, :edit, :show]
   before_action :set_peopleshops, only: [:new, :edit, :show]
 
-  require 'net/http'
-  include Prerender
   include ApiGeocoder
 
   # GET /shops


### PR DESCRIPTION
close #53 

## 問題
Facebookの更新でErrorになるので解消する
記事公開時にキャッシュを作成するように調整する

## 対応
* 過去の無駄なソースを削除
* Facebookのキャッシュを作成できるように修正
* 本番のみで動作するように修正
* 記事公開時にキャッシュを作成するように修正



