### PR TITLE
facebookのキャッシュ問題対応

### DIFF
--- a/app/controllers/api_posts_controller.rb
+++ b/app/controllers/api_posts_controller.rb
@@ -176,8 +176,15 @@ class ApiPostsController < ApplicationController
       end
     # 公開処理の場合
     else
+      # アイキャッチ画像設定
+      eyeCatchImage = @post.image
+      @post.post_details.each do |post_detail|
+        if post_detail.is_eye_catch
+          eyeCatchImage = post_detail.image
+        end
+      end
       cache_url = "http://www.rekishoku.jp/app/post/" + @post[:id].to_s
-      create_page_cache(cache_url, @post[:image], @post[:title], @post[:content])
+      create_page_cache(cache_url, eyeCatchImage, @post[:title], @post[:content])
       result = @post.update(post_params)
     end
     if result

--- a/app/controllers/api_posts_controller.rb
+++ b/app/controllers/api_posts_controller.rb
@@ -177,7 +177,7 @@ class ApiPostsController < ApplicationController
     # 公開処理の場合
     else
       cache_url = "http://www.rekishoku.jp/app/post/" + @post[:id].to_s
-      create_page_cache(cache_url)
+      create_page_cache(cache_url, @post[:image], @post[:title], @post[:content])
       result = @post.update(post_params)
     end
     if result

--- a/app/controllers/concerns/prerender.rb
+++ b/app/controllers/concerns/prerender.rb
@@ -1,7 +1,7 @@
 module Prerender
 
   # API実行用のURLを返却
-  def create_page_cache(cache_url)
+  def create_page_cache(cache_url, image, title, content)
     if Rails.env == 'production'
       # 通信用
       http_client = HTTPClient.new
@@ -20,7 +20,7 @@ module Prerender
 
       # Facebook対応
       endpoint_uri = 'https://graph.facebook.com'
-      request_content = {:scrape => "true", :id => cache_url}
+      request_content = {:scrape => "true", :id => cache_url, :type => "website", :title => title, :image => image, :description => content}
       content_json = request_content.to_json
       begin
         http_client.post_content(endpoint_uri, content_json, 'Content-Type' => 'application/json')

--- a/app/controllers/features_controller.rb
+++ b/app/controllers/features_controller.rb
@@ -2,6 +2,8 @@ class FeaturesController < ApplicationController
   load_and_authorize_resource
   before_action :set_feature, only: [:edit, :update, :destroy]
 
+  include Prerender
+
   # POST /feature
   # POST /feature.json
   def create
@@ -12,6 +14,8 @@ class FeaturesController < ApplicationController
       @feature = Feature.new(feature_params)
     end
     @feature.save
+    cache_url = "http://www.rekishoku.jp/app/feature/" + @feature[:id].to_s
+    create_page_cache(cache_url, @feature[:image], @feature[:title], @feature[:content])
     redirect_to "/admin/feature"
   end
 

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -5,6 +5,7 @@ class ShopsController < ApplicationController
   before_action :set_peopleshops, only: [:new, :edit, :show]
 
   include ApiGeocoder
+  include Prerender
 
   # GET /shops
   # GET /shops.json
@@ -46,6 +47,8 @@ class ShopsController < ApplicationController
     # 緯度経度と歴食度を代入する
     @shop = Shop.new(shop_params.merge(latitude: addressPlace[0], longitude: addressPlace[1], total_level: total, history_level: setShopLevel[0], building_level: setShopLevel[1], menu_level: setShopLevel[2], person_level: setShopLevel[3], episode_level: setShopLevel[4]))
     @shop.save
+    cache_url = "http://www.rekishoku.jp/app/shop/" + @shop[:id].to_s
+    create_page_cache(cache_url, @shop[:subimage], @shop[:name], @shop[:description])
     redirect_to "/admin/shop"
   end
 

--- a/lib/cache_make.rb
+++ b/lib/cache_make.rb
@@ -31,7 +31,21 @@ module RailsAdmin
                         elsif request.put?
                           # 通信用
                           cache_url = "http://www.rekishoku.jp/app/"+ params[:model_name] + "/" + params[:page][:name].to_s
-                          create_page_cache(cache_url)
+
+                          ## キャッシュ可能なDBでのキャッシュ作成対応
+                          case params[:model_name]
+                          when "shop"
+                            cache_data = Shop.find(params[:page][:name])
+                            create_page_cache(cache_url, cache_data[:subimage], cache_data[:name], cache_data[:description])
+                          when "post"
+                            cache_data = Post.find(params[:page][:name])
+                            create_page_cache(cache_url, cache_data[:image], cache_data[:title], cache_data[:content])
+                          when "feature"
+                            cache_data = Feature.find(params[:page][:name])
+                            create_page_cache(cache_url, cache_data[:image], cache_data[:title], cache_data[:content])
+                          else
+                            print("キャッシュ実行不可")
+                          end
                         else
                           raise "エラーメッセージ"
                         end


### PR DESCRIPTION
## 問題
Facebookキャッシュの作成完了がうまくできていなかった。

## 原因
必要なパラメータを渡していなかったため、うまくキャッシュが作成できなかった

## 対応
管理画面では、店舗、記事、特集のキャッシュ作成ボタンを有効する。(他も必要に応じて対応可能)