### PR TITLE
特集詳細で、連携DBがなくても作成できるように修正

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -684,8 +684,6 @@ RailsAdmin.config do |config|
             end
             field :related do
               label "紐付けする情報"
-              help "必須"
-              required true
             end
         end
        end


### PR DESCRIPTION
close #61 

## 内容
特集詳細で、「店舗」or 「外部リンク」 or 「記事」を紐付けないと作成できなかった

## 修正内容
紐付けする情報を必須から解除

## 変更ファイル
rails_admin.rb

## 注意点
フロント側が「順番のみ」でレスポンスが返ってくる可能性がございます。
その場合で、正常に動作するか確認が必要ですmm