### PR TITLE
建物名を追加して、緯度経度計算

### DIFF
--- a/app/controllers/external_links_controller.rb
+++ b/app/controllers/external_links_controller.rb
@@ -7,7 +7,7 @@ class ExternalLinksController < ApplicationController
   # POST /external_links.json
   def create
     # 住所から緯度経度を求める
-    addressPlace = get_geocoder(external_link_params[:province]+external_link_params[:city]+external_link_params[:address1]);
+    addressPlace = get_geocoder(external_link_params[:province]+external_link_params[:city]+external_link_params[:address1]+external_link_params[:address2]);
     # 緯度経度を代入する
     @external_link = ExternalLink.new(external_link_params.merge(latitude: addressPlace[0], longitude: addressPlace[1]))
     @external_link.save
@@ -18,7 +18,7 @@ class ExternalLinksController < ApplicationController
   # PATCH/PUT /external_links/1.json
   def update
     # 住所から緯度経度を求める
-    addressPlace = get_geocoder(external_link_params[:province]+external_link_params[:city]+external_link_params[:address1]);
+    addressPlace = get_geocoder(external_link_params[:province]+external_link_params[:city]+external_link_params[:address1]+external_link_params[:address2]);
     # 緯度経度を代入する
     @external_link.update(external_link_params.merge(latitude: addressPlace[0], longitude: addressPlace[1]))
     redirect_to "/admin/external_link"

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -31,7 +31,7 @@ class ShopsController < ApplicationController
   # POST /shops.json
   def create
     # 住所から緯度経度を求める
-    addressPlace = get_geocoder(shop_params[:province]+shop_params[:city]+shop_params[:address1]);
+    addressPlace = get_geocoder(shop_params[:province]+shop_params[:city]+shop_params[:address1]+shop_params[:address2]);
     #歴食度_合計
     levelArray  = ["history_level", "building_level", "menu_level", "person_level", "episode_level"]
     setShopLevel = [nil, nil, nil, nil, nil]
@@ -56,7 +56,7 @@ class ShopsController < ApplicationController
   # PATCH/PUT /shops/1.json
   def update
     # 住所から緯度経度を求める
-    addressPlace = get_geocoder(shop_params[:province]+shop_params[:city]+shop_params[:address1]);
+    addressPlace = get_geocoder(shop_params[:province]+shop_params[:city]+shop_params[:address1]+shop_params[:address2]);
     #歴食度_合計
     levelArray  = ["history_level", "building_level", "menu_level", "person_level", "episode_level"]
     setShopLevel = [nil, nil, nil, nil, nil]


### PR DESCRIPTION
## 問題
建物名を含めずに緯度経度を計算していた。

## 改修内容
パラメータに建物名を追加した場合で、緯度経度をするように対応しました。