### PR TITLE
管理画面の特集の作者登録/カテゴリー処理部分の修正

### DIFF
--- a/app/controllers/features_controller.rb
+++ b/app/controllers/features_controller.rb
@@ -8,15 +8,9 @@ class FeaturesController < ApplicationController
   # POST /feature.json
   def create
 
-    if feature_params[:category_id] == "1"
-      category = Category.where(name: 'TOUR').first
-    else
-      category = Category.where(name: 'PICKUP').first
-    end
-
     if feature_time_params[:published_at] != ""
       setPublishedAt = feature_time_params[:published_at].split(/\D+/)
-      @feature = Feature.new(feature_params.merge(category_id: category.id, published_at: Time.zone.local(setPublishedAt[0],setPublishedAt[1],setPublishedAt[2],setPublishedAt[3],setPublishedAt[4])))
+      @feature = Feature.new(feature_params.merge(published_at: Time.zone.local(setPublishedAt[0],setPublishedAt[1],setPublishedAt[2],setPublishedAt[3],setPublishedAt[4])))
     else
       @feature = Feature.new(feature_params)
     end
@@ -29,17 +23,10 @@ class FeaturesController < ApplicationController
   # PATCH/PUT /feature/1
   # PATCH/PUT /feature/1.json
   def update
-
-    if feature_params[:category_id] == "1"
-      category = Category.where(name: 'TOUR').first
-    else
-      category = Category.where(name: 'PICKUP').first
-    end
-
     ## 公開日の設定
     if feature_time_params[:published_at] != ""
       setPublishedAt = feature_time_params[:published_at].split(/\D+/)
-      @feature.update(feature_params.merge(category_id: category.id, published_at: Time.zone.local(setPublishedAt[0],setPublishedAt[1],setPublishedAt[2],setPublishedAt[3],setPublishedAt[4])))
+      @feature.update(feature_params.merge(published_at: Time.zone.local(setPublishedAt[0],setPublishedAt[1],setPublishedAt[2],setPublishedAt[3],setPublishedAt[4])))
     else
       @feature.update(feature_params)
     end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -691,7 +691,14 @@ RailsAdmin.config do |config|
           end
           field :user_id, :enum do
             enum do
-              Hash[ ['RYO','Haruka','MIO','戸田江美','小太刀御禄','まさお'].zip(['6','7','11','12','13','16']) ]
+              setData = User.all
+              ids = []
+              names = []
+              setData.each do |set|
+                ids.push(set.id.to_s)
+                names.push(set.username)
+              end
+              Hash[ names.zip(ids) ]
             end
             label "ライター"
             required true


### PR DESCRIPTION
close  #67 

## 問題
[WIP]をつけた状態のものをマージしたため、特集のカテゴリーでどれを選んでも、PICKUPになる問題発生

## 対応内容
PICKUPのみ選択問題の対応
特集でライターを綺麗に表示できるように対応

