### PR TITLE
特集詳細コメントや本文のみ、サーバの対応完了

### DIFF
--- a/app/controllers/api_features_controller.rb
+++ b/app/controllers/api_features_controller.rb
@@ -112,9 +112,15 @@ class ApiFeaturesController < ApplicationController
           # 対応するExternalLinkの情報を取得する
           obj = get_external_link_json(feature_detail.related)
         end
-        people += get_people(feature_detail.related)
-        obj.store("feature_detail",feature_detail)
-        feature_details.push(obj)
+
+        if feature_detail[:related_type] != ""
+          people += get_people(feature_detail.related)
+          obj.store("feature_detail",feature_detail)
+          feature_details.push(obj)
+        else
+          obj =  { "feature_detail" => feature_detail }
+          feature_details.push(obj)
+        end
       end
 
       periods += get_periods(people)
@@ -127,6 +133,7 @@ class ApiFeaturesController < ApplicationController
         "people" => people.uniq,
         "periods" => periods.uniq,
         "user" => user }
+
       render json: feature
     else
       feature = { "feature" => "" }


### PR DESCRIPTION
##  問題
特集詳細作成時にコメントや本文のみで作成すると、記事を表示にErrorが出ていました。
それが起きないように修正しました。

## 修正内容
feature_detail[:related_type] != ""の場合に人物を追加するようにして対応

## 要注意
Front側でコメントや本文のみでも、ずっとSPOTが表示される。。
これが表示されないようにする必要あります。