### PR TITLE
related_typeのnull対応

### DIFF
--- a/app/controllers/api_features_controller.rb
+++ b/app/controllers/api_features_controller.rb
@@ -113,12 +113,12 @@ class ApiFeaturesController < ApplicationController
           obj = get_external_link_json(feature_detail.related)
         end
 
-        if feature_detail[:related_type] != ""
-          people += get_people(feature_detail.related)
-          obj.store("feature_detail",feature_detail)
+        if feature_detail[:related_type].nil?
+          obj =  { "feature_detail" => feature_detail }
           feature_details.push(obj)
         else
-          obj =  { "feature_detail" => feature_detail }
+          people += get_people(feature_detail.related)
+          obj.store("feature_detail",feature_detail)
           feature_details.push(obj)
         end
       end

--- a/app/controllers/feature_details_controller.rb
+++ b/app/controllers/feature_details_controller.rb
@@ -1,0 +1,40 @@
+class FeatureDetailsController < ApplicationController
+  load_and_authorize_resource
+  before_action :set_feature_detail, only: [:edit, :update, :destroy]
+
+  # POST /feature_detail
+  # POST /feature_detail.json
+  def create
+    if feature_detail_params[:related_type] == ""
+      @featureDetails = FeatureDetail.new(feature_detail_params.merge(related_type: nil))
+    else
+      @featureDetails = FeatureDetail.new(feature_detail_params)
+    end
+    @featureDetails.save
+    redirect_to "/admin/feature_detail"
+  end
+
+  # PATCH/PUT /feature_detail/1
+  # PATCH/PUT /feature_detail/1.json
+  def update
+    ## 公開日の設定
+    if feature_detail_params[:related_type] == ""
+      @featureDetails.update(feature_detail_params.merge(related_type: nil))
+    else
+      @featureDetails.update(feature_detail_params)
+    end
+    redirect_to "/admin/feature_detail"
+  end
+
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_feature_detail
+      @featureDetails = FeatureDetail.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def feature_detail_params
+      params.require(:feature_detail).permit(:title, :content, :related_type, :related_id, :order, :id)
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   # ssl証明書発行用
   get ".well-known/acme-challenge/:id" => "app_route#letsencrypt"
 
-  ### 
+  ###
   # API route　
   ###
   # POSTS
@@ -73,11 +73,15 @@ Rails.application.routes.draw do
   post 'admin/feature/new', to: 'features#create'
   put 'admin/feature/:id/edit', to: 'features#update'
 
+  # ADMIN_FEATURE
+  post 'admin/feature_detail/new', to: 'feature_details#create'
+  put 'admin/feature_detail/:id/edit', to: 'feature_details#update'
+
   # ADMIN_ ExternalLink
   post 'admin/external_link/new', to: 'external_links#create'
   put 'admin/external_link/:id/edit', to: 'external_links#update'
 
-  ### 
+  ###
   # Site Map
   ###
   case Rails.env


### PR DESCRIPTION
## 問題
related_typeが空文字であった

## 対応内容
related_typeが空文字だった場合に、NULLを保存
特集APIの変更箇所対応